### PR TITLE
Basic tools docs

### DIFF
--- a/docs/Tools/index.md
+++ b/docs/Tools/index.md
@@ -88,7 +88,7 @@ brew install node
 
 ### _Lando_
 
-Lando is a container managment tool that really helps software development go smoothly. Basically, it installs Docker and creates a container, with a complete development stack, for your application. This is very convenient for working with Drupal as it handles OS, server, database, and PHP for us.
+[Lando](https://lando.dev/) is a container managment tool that really helps software development go smoothly. Basically, it installs Docker and creates a container, with a complete development stack, for your application. This is very convenient for working with Drupal as it handles OS, server, database, and PHP for us.
 
 To install it select the [latest release](https://github.com/lando/lando/releases). The installers are found in the 'assets' section. Download and run the appropriate installer for your computer:
 


### PR DESCRIPTION
# Intended scope

Creation of a Tools directory for tool documentation and create a basic, beginning tools and set-up document. Other documents, like for Drupal 9 for example, can be added individually to the Tools directory.

takes care of some tasks found int #4 